### PR TITLE
Fixes saving of Keypad modifier keys in settings

### DIFF
--- a/src/ctrl/KeyBinding.cpp
+++ b/src/ctrl/KeyBinding.cpp
@@ -152,11 +152,12 @@ void KeyBinding::setSerialValue(const QString& aValue)
     mKeyCode = key;
     mSubKeyCode = subKey;
     mModifiers = Qt::NoModifier;
+    // Values (0x01, 0x02, etc.) are short versions of the Qt modifier enums (Qt::<XXXModifier>)
     if (mod & 0x01) mModifiers |= Qt::ControlModifier;
     if (mod & 0x02) mModifiers |= Qt::ShiftModifier;
     if (mod & 0x04) mModifiers |= Qt::AltModifier;
-	if (mod & 0x06) mModifiers |= Qt::KeypadModifier;
     if (mod & 0x08) mModifiers |= Qt::MetaModifier;
+    if (mod & 0x20) mModifiers |= Qt::KeypadModifier;
 
     if (!isValidBinding())
     {
@@ -172,8 +173,8 @@ QString KeyBinding::serialValue() const
     mod |= mModifiers.testFlag(Qt::ControlModifier) ? 0x01 : 0x00;
     mod |= mModifiers.testFlag(Qt::ShiftModifier) ? 0x02 : 0x00;
     mod |= mModifiers.testFlag(Qt::AltModifier) ? 0x04 : 0x00;
-	mod |= mModifiers.testFlag(Qt::KeypadModifier) ? 0x06 : 0x00;
     mod |= mModifiers.testFlag(Qt::MetaModifier) ? 0x08 : 0x00;
+    mod |= mModifiers.testFlag(Qt::KeypadModifier) ? 0x20 : 0x00;
     return QString::number(mKeyCode) + "," + QString::number(mod) + "," + QString::number(mSubKeyCode);
 }
 


### PR DESCRIPTION
Fixes #4 
I was mapping custom values instead of using the correct Qt enums.