### PR TITLE
Fix `SMPTE` and `Seconds : Frame` time formats

### DIFF
--- a/src/core/TimeFormat.cpp
+++ b/src/core/TimeFormat.cpp
@@ -24,16 +24,17 @@ const QString TimeFormat::frameToString(const int aFrame, const TimeFormatType a
     case TimeFormatType_Seconds_Frames: { // (SS:FF)
         double min = 0.0;
         double max = 60.0;
-        double v = static_cast<double>(aFrame);
 
         double nMin = 0;
         double nMax = 1;
 
-        double rangeMaxSeconds = remap(static_cast<double>(mRange.max()),min,max,nMin,nMax);
-        double s = remap(v,min,max,nMin,nMax);
+        int rangeMaxSeconds = static_cast<int>(util::MathUtil::remap(mRange.max(),min,max,nMin,nMax));
+        double seconds = util::MathUtil::remap(aFrame,min,max,nMin,nMax);
 
         QString n;
-        n.sprintf("%0*d:%0*d", QString::number(rangeMaxSeconds).length(),static_cast<int>(s) ,QString::number(mRange.max()).length(),aFrame);
+        n.sprintf("%0*d:%02d",
+                  QString::number(rangeMaxSeconds).length(), static_cast<int>(seconds),
+                  static_cast<int>(util::MathUtil::cycle(aFrame, 0.0, 60.0)));
 
         return n;
     }
@@ -41,17 +42,18 @@ const QString TimeFormat::frameToString(const int aFrame, const TimeFormatType a
     case TimeFormatType_Timecode_SMPTE: { // (HH:MM:SS:FF)
         double min = 0.0;
         double max = 60.0;
-        double v = static_cast<double>(aFrame);
 
         double nMin = 0;
         double nMax = 1000.0;
 
-        double ms = remap(v,min,max,nMin,nMax);
+        double ms = util::MathUtil::remap(aFrame,min,max,nMin,nMax);
 
         DDHHMMSSmmm timeStruct = msToDDHHMMSSmmm(ms);
 
         QString n;
-        n.sprintf("%02d:%02d:%02d:%0*d", timeStruct.hours, timeStruct.minutes,timeStruct.seconds,QString::number(mRange.max()).length(),aFrame);
+        n.sprintf("%02d:%02d:%02d:%02d",
+                  timeStruct.hours, timeStruct.minutes,timeStruct.seconds,
+                  static_cast<int>(util::MathUtil::cycle(aFrame, 0.0, 60.0)));
 
         return n;
     }
@@ -59,12 +61,11 @@ const QString TimeFormat::frameToString(const int aFrame, const TimeFormatType a
     case TimeFormatType_Timecode_HHMMSSmmm: { // (HH:MM:SS:mmm)
         double min = 0.0;
         double max = 60.0;
-        double v = static_cast<double>(aFrame);
 
         double nMin = 0;
         double nMax = 1000.0;
 
-        double ms = remap(v,min,max,nMin,nMax);
+        double ms = util::MathUtil::remap(aFrame,min,max,nMin,nMax);
 
         DDHHMMSSmmm timeStruct = msToDDHHMMSSmmm(ms);
 
@@ -79,11 +80,6 @@ const QString TimeFormat::frameToString(const int aFrame, const TimeFormatType a
     }
 }
 
-double TimeFormat::remap(double value, double min, double max, double nMin, double nMax)
-{
-    // Linear range conversion
-    return (((value - min) * (nMax - nMin)) / (max - min)) + nMin;
-}
 
 DDHHMMSSmmm TimeFormat::msToDDHHMMSSmmm(double ms)
 {

--- a/src/core/TimeFormat.h
+++ b/src/core/TimeFormat.h
@@ -6,6 +6,7 @@
 
 #include <QString>
 #include "util/Range.h"
+#include "util/MathUtil.h"
 
 namespace core
 {

--- a/src/ctrl/time/time_Renderer.cpp
+++ b/src/ctrl/time/time_Renderer.cpp
@@ -48,10 +48,10 @@ void Renderer::renderLines(const QVector<TimeLineRow>& aRows, const QRect& aCame
             const int sepa = row.node->timeLine()->validTypeCount();
             for (int i = 1; i < sepa; ++i)
             {
-                const float h = (float)rect.height() / sepa;
+                const float h = static_cast<float>(rect.height()) / sepa;
                 const float y = rect.top() + i * h;
-                const QPointF v0(rect.left(), y);
-                const QPointF v1(rect.right(), y);
+                const QPointF v0(rect.left(), static_cast<double>(y));
+                const QPointF v1(rect.right(), static_cast<double>(y));
                 mPainter.drawLine(v0, v1);
 
             }
@@ -67,9 +67,9 @@ void Renderer::renderLines(const QVector<TimeLineRow>& aRows, const QRect& aCame
                     continue;
                 }
 
-                const float h = (float)rect.height() / sepa;
+                const float h = static_cast<float>(rect.height()) / sepa;
                 mPainter.drawText(
-                            QRect(textLeft, rect.top() + (int)i * h, textWidth, (int)h),
+                            QRect(textLeft, rect.top() + static_cast<int>(i * h), textWidth, static_cast<int>(h)),
                             TimeLine::getTimeKeyName(type),
                             QTextOption(Qt::AlignCenter));
                 ++i;
@@ -111,7 +111,7 @@ void Renderer::renderHeader(int aHeight, int aFps)
         const QPoint lt(mMargin, cameraRect.top());
         const QPoint rb = lt + QPoint(mScale->maxPixelWidth(), aHeight);
 
-        const TimeFormat timeFormat(mRange,aFps);
+        const TimeFormat timeFormat(util::Range(0, mScale->maxFrame()), aFps);
         const TimeFormatType timeScaleFormatVar = static_cast<TimeFormatType>(settings.value("generalsettings/ui/timescaleformat").toInt());
 
         mPainter.setPen(QPen(kBrush, 1));
@@ -138,7 +138,7 @@ void Renderer::renderHeader(int aHeight, int aFps)
 
 void Renderer::renderHandle(const QPoint& aPoint, int aRange)
 {
-    const QPoint pos = aPoint + QPoint(0, -(int)mCamera.leftTopPos().y());
+    const QPoint pos = aPoint + QPoint(0, -static_cast<int>(mCamera.leftTopPos().y()));
     const int range = aRange;
 
     const QBrush kBrushBody(QColor(230, 230, 230, 180));
@@ -170,8 +170,8 @@ void Renderer::drawKeys(const ObjectNode* aNode, const TimeLineRow& aRow)
     const QBrush kBrushKeyBody1(QColor(145, 145, 145, 255));
     const QBrush kBrushKeyBody2(QColor(240, 240, 240, 255));
     const QBrush kBrushKeyEdge(QColor(90, 90, 100, 255));
-    QPointF holder[4] = { QPointF(0.0f, -4.2f), QPointF( 4.2f, 0.0f),
-                          QPointF(0.0f,  4.2f), QPointF(-4.2f, 0.0f) };
+    QPointF holder[4] = { QPointF(0.0, -4.2), QPointF( 4.2, 0.0),
+                          QPointF(0.0,  4.2), QPointF(-4.2, 0.0) };
 
     if (aNode && aNode->timeLine())
     {
@@ -199,7 +199,7 @@ void Renderer::drawKeys(const ObjectNode* aNode, const TimeLineRow& aRow)
                 mPainter.setBrush(isFocused ? kBrushKeyBody2 : kBrushKeyBody1);
 
                 auto attr = mScale->attribute(itr.key());
-                QPointF pos(left + attr.grid.x() + 0.5f, height + 0.5f);
+                QPointF pos(left + attr.grid.x() + 0.5, static_cast<double>(height + 0.5f));
 
                 if (isSlimmed)
                 {
@@ -212,10 +212,10 @@ void Renderer::drawKeys(const ObjectNode* aNode, const TimeLineRow& aRow)
                     */
                     //mPainter.drawEllipse(pos, 3.0f, 1.5f);
                     const QPointF poly[] = {
-                        pos + QPointF(-3.0f, -2.0f),
-                        pos + QPointF( 3.0f, -2.0f),
-                        pos + QPointF( 3.0f,  2.0f),
-                        pos + QPointF(-3.0f,  2.0f) };
+                        pos + QPointF(-3.0, -2.0),
+                        pos + QPointF( 3.0, -2.0),
+                        pos + QPointF( 3.0,  2.0),
+                        pos + QPointF(-3.0,  2.0) };
                     mPainter.drawConvexPolygon(poly, 4);
                 }
                 else if (itr.value()->canHoldChild())
@@ -227,7 +227,7 @@ void Renderer::drawKeys(const ObjectNode* aNode, const TimeLineRow& aRow)
                 }
                 else
                 {
-                    mPainter.drawEllipse(pos, 3.0f, 3.0f);
+                    mPainter.drawEllipse(pos, 3.0, 3.0);
                 }
 
                 ++itr;
@@ -262,7 +262,7 @@ void Renderer::drawChildKeys(const ObjectNode* aNode, const QPoint& aPos)
                 {
                     auto attr = mScale->attribute(itr.key());
                     QPointF pos[3];
-                    pos[0] = QPointF(aPos.x() + attr.grid.x() + 0.5f, aPos.y());
+                    pos[0] = QPointF(aPos.x() + attr.grid.x() + 0.5, aPos.y());
                     pos[1] = pos[0] + QPointF( 3, -5);
                     pos[2] = pos[0] + QPointF(-3, -5);
                     mPainter.drawConvexPolygon(pos, 3);

--- a/src/ctrl/time/time_Scaler.cpp
+++ b/src/ctrl/time/time_Scaler.cpp
@@ -52,6 +52,11 @@ int Scaler::frame(int aPixelWidth) const
     return std::max(0, std::min(mMaxFrame, frame));
 }
 
+int Scaler::maxFrame() const
+{
+    return mMaxFrame;
+}
+
 Scaler::Attribute Scaler::attribute(int aFrame) const
 {
     Attribute attr;

--- a/src/ctrl/time/time_Scaler.h
+++ b/src/ctrl/time/time_Scaler.h
@@ -24,6 +24,7 @@ public:
     int pixelWidth(int aFrame) const;
     int maxPixelWidth() const;
     int frame(int aPixelWidth) const;
+    int maxFrame() const;
     Attribute attribute(int aFrame) const;
 
 private:

--- a/src/util/MathUtil.cpp
+++ b/src/util/MathUtil.cpp
@@ -6,15 +6,15 @@ namespace util
 
 QVector2D MathUtil::getRotateVectorRad(const QVector2D& aVec, float aRotate)
 {
-    const float s = qSin(aRotate);
-    const float c = qCos(aRotate);
+    const float s = static_cast<float>(qSin(static_cast<double>(aRotate)));
+    const float c = static_cast<float>(qCos(static_cast<double>(aRotate)));
     return QVector2D(c * aVec.x() - s * aVec.y(), s * aVec.x() + c * aVec.y());
 }
 
 QPointF MathUtil::getRotateVectorRad(const QPointF& aVec, float aRotate)
 {
-    const float s = qSin(aRotate);
-    const float c = qCos(aRotate);
+    const double s = qSin(static_cast<double>(aRotate));
+    const double c = qCos(static_cast<double>(aRotate));
     return QPointF(c * aVec.x() - s * aVec.y(), s * aVec.x() + c * aVec.y());
 }
 
@@ -34,8 +34,8 @@ float MathUtil::getClockwiseRotationRad(const QVector2D& aFrom, const QVector2D&
 
     const float from = getAngleRad(aFrom);
     const float to = getAngleRad(aTo);
-    const float rotate = to - from;
-    return rotate < 0 ? rotate : (float)(rotate - 2.0 * M_PI);
+    const double rotate = static_cast<const double>(to - from);
+    return static_cast<float>(rotate < 0 ? rotate : (rotate - 2.0 * M_PI));
 }
 
 QVector2D MathUtil::blendVectorByClockwiseRotation(

--- a/src/util/MathUtil.h
+++ b/src/util/MathUtil.h
@@ -32,26 +32,26 @@ public:
 
     static float getRadianFromDegree(float aDegree)
     {
-        return (float)((aDegree * M_PI) / 180.0);
+        return static_cast<float>((static_cast<double>(aDegree) * M_PI) / 180.0);
     }
 
     static float getDegreeFromRadian(float aRadian)
     {
-        return (float)((aRadian * 180.0) / M_PI);
+        return static_cast<float>((static_cast<double>(aRadian) * 180.0) / M_PI);
     }
 
     static float normalizeAngleRad(float aAngle)
     {
         static const double kPi2 = 2.0 * M_PI;
-        const int round = (int)(aAngle / kPi2);
+        const int round = static_cast<int>(static_cast<double>(aAngle) / kPi2);
         return (aAngle >= 0.0f) ?
-                    (float)(aAngle - kPi2 * round) :
-                    (float)(aAngle - kPi2 * (round - 1));
+                    static_cast<float>(static_cast<double>(aAngle) - kPi2 * round) :
+                    static_cast<float>(static_cast<double>(aAngle) - kPi2 * (round - 1));
     }
 
     static float normalizeAngleDeg(float aAngle)
     {
-        const int round = (int)(aAngle / 360.0f);
+        const int round = static_cast<int>(aAngle / 360.0f);
         return (aAngle >= 0.0f) ?
                     aAngle - 360.0f * round :
                     aAngle - 360.0f * (round - 1);
@@ -67,15 +67,15 @@ public:
 
     static float normalizeSignedAngleRad(float aAngle)
     {
-        double angle = normalizeAngleRad(aAngle);
+        double angle = static_cast<double>(normalizeAngleRad(aAngle));
         if (angle > M_PI) angle -= 2.0 * M_PI;
-        return (float)angle;
+        return static_cast<float>(angle);
     }
 
     static float getAngleRad(const QVector2D& aVec)
     {
         if (aVec.isNull()) return 0.0f;
-        return qAtan2(aVec.y(), aVec.x());
+        return static_cast<float>(qAtan2(static_cast<double>(aVec.y()), static_cast<double>(aVec.x())));
     }
 
     static float getAngleDeg(const QVector2D& aVec)
@@ -85,7 +85,10 @@ public:
 
     static QVector2D getVectorFromPolarCoord(float aLength, float aAngleRad)
     {
-        return QVector2D(qCos(aAngleRad), qSin(aAngleRad)) * aLength;
+        return QVector2D(
+                    static_cast<float>(qCos(static_cast<double>(aAngleRad))),
+                    static_cast<float>(qSin(static_cast<double>(aAngleRad))) * aLength
+                    );
     }
 
     static float getAngleDifferenceRad(float aAngleFrom, float aAngleTo)
@@ -134,6 +137,19 @@ public:
         if (QVector2D::dotProduct(aA.dir, aB.dir) < 0.0f)
             if (QVector2D::dotProduct(aB.start - aA.start, aA.dir) > 0.0f) return true;
         return  false;
+    }
+
+    static double remap(const double value, const double min, const double max, const double nMin, const double nMax)
+    {
+        return (((value - min) * (nMax - nMin)) / (max - min)) + nMin;
+    }
+
+    static double cycle( const double value, const double start, const double end )
+    {
+        const double length      = end - start;
+        const double offsetValue = value - start; // value relative to 0
+        return ( offsetValue - ( qFloor( offsetValue / length ) * length ) ) + start;
+        // + start to reset back to start of original range
     }
 
 private:


### PR DESCRIPTION
* Fix `SMPTE` and `Seconds : Frame` time formats to correctly start over when reaching end of FPS scale (bug report via Discord by @Jose-Moreno). So @ 60fps is kept between 0-59, @ 30 fps between 0-29 etc.
* Remove superfluous variables and static_casts as `int` to `double` is automatic. (Got a little carried away :slightly_smiling_face: )
* Expose private "maxFrame" member value via getter in time_Scaler class
* Move TimeFormat::remap to util::MathUtil::remap as that's where it belongs
* Add cycle function to util::MathUtil
* Fix a few: "old-style cast..." and float vs. double conversions warning messages in touched files

**Notes**
@herace A few oddities arose from this fix - as the two mentioned time formats will now always end in `:00` on the timeline¹, which IMO makes them a bit irrelevant to even render **but** it would probably confuse users if we start stripping stuff from the time codes on the timeline? (The new timeline info widget is untouched ofc...)

My gut feeling is that we shouldn't start stripping stuff from a specific format...
Although it's tempting to also strip e.g. unused `00:` from hours - as the majority will probably never have an hour or more of AnimeEffects animation going on...

¹:  See the new TimelineInfoWidget for reference on values in between marks on the timeline